### PR TITLE
Fix bug can not show the second latest post's image 

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ description: "A great Jekyll theme developed by Sal @wowthemesnet."
                 {% if second_post.image %}
                 <div class="col-md-4">
                 <a href="{{site.baseurl}}{{second_post.url}}">
-                 <img class="w-100" src="{% if second_post.image contains "://" %}{{ second_post.image }}{% else %}{{ second_post.image | absolute_url }}{% endif %}" alt="{{ second_post.title }}">
+                 <img class="w-100" src="{% if second_post.image contains "://" %}{{ second_post.image }}{% else %}{{second_post.baseurl}}/{{ second_post.image }}{% endif %}" alt="{{ second_post.title }}">
                 </a>
                 </div>
                 {% endif %}                


### PR DESCRIPTION
Hello, 

Current, I am using your theme on my website. But the second latest post has the wrong URL ( the post's image can not render like below picture ), it uses a `second_post.image | absolute_url` instead of  `{{second_post.baseurl}}/{{ second_post.image }}`. I think this is someone's mistake.

![image](https://user-images.githubusercontent.com/26034284/63222456-4798cd00-c1d2-11e9-8279-a6554c8890e0.png)
