### PR TITLE
add gem kramdown-parser-gfm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby RUBY_VERSION
 #
 
 # If you have any plugins, put them here!
+gem 'kramdown-parser-gfm'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 group :jekyll_plugins do
     gem 'jekyll-feed'


### PR DESCRIPTION
Theme fails to build with Stackbit and some other deployment services

```
Dependency Error: Yikes! It looks like you don't have kramdown-parser-gfm or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem.
```

adding this gem to the Gemfile fixes the problem.