### PR TITLE
fix 2nd latest post image url formation issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ description: "A great Jekyll theme developed by Sal @wowthemesnet."
                 {% if second_post.image %}
                 <div class="col-md-4">
                 <a href="{{site.baseurl}}{{second_post.url}}">
-                 <img class="w-100" src="{% if second_post.image contains "://" %}{{ second_post.image }}{% else %}{{ second_post.image | absolute_url }}{% endif %}" alt="{{ second_post.title }}">
+                 <img class="w-100" src="{% if second_post.image contains "://" %}{{ second_post.image }}{% else %}{{site.baseurl}}/{{ second_post.image }}{% endif %}" alt="{{ second_post.title }}">
                 </a>
                 </div>
                 {% endif %}                


### PR DESCRIPTION
The 2nd post image was not being rendered to a URL formation issue.

**Old code in index.html file**

`<img class="w-100" src="{% if second_post.image contains "://" %}{{ second_post.image }}{% else %}{{ second_post.image | absolute_url }}{% endif %}" alt="{{ second_post.title }}">`

**Fix in index.html file**

`<img class="w-100" src="{% if second_post.image contains "://" %}{{ second_post.image }}{% else %}{{site.baseurl}}/{{second_post.image}}{% endif %}" alt="{{ second_post.title }}">`